### PR TITLE
MejoraAnimacionYLogicaTurnos

### DIFF
--- a/Animaciones.cpp
+++ b/Animaciones.cpp
@@ -18,7 +18,6 @@ void Animaciones::animacionDado8Caras(float* rotDadox, float* rotDadoy, float* r
         // para obtener el numero 1 rotar -52 grados en eje x 
         // para obtener el numero 6 rotar 52 grados en eje x 
         static bool initialized = false;
-        
         if (!initialized) {
             std::srand(static_cast<unsigned int>(std::time(nullptr)));
             initialized = true;
@@ -40,7 +39,7 @@ void Animaciones::animacionDado8Caras(float* rotDadox, float* rotDadoy, float* r
                 *rotDadox -= (*rotDadoxOffset) * (*deltaTime);
             }
             if (*rotDadoy < 360) {
-                *rotDadoy += (*rotDadoyOffset) * .7*(*deltaTime);
+                *rotDadoy += (*rotDadoyOffset) * .7 * (*deltaTime);
             }
             break;
 
@@ -55,13 +54,13 @@ void Animaciones::animacionDado8Caras(float* rotDadox, float* rotDadoy, float* r
 
         case 3:
             if (*rotDadox < 360 + 52) {
-                *rotDadox += (*rotDadoxOffset) * .7*(*deltaTime);
+                *rotDadox += (*rotDadoxOffset) * .7 * (*deltaTime);
             }
             if (*rotDadoz > -360) {
-                *rotDadoz -= (*rotDadozOffset) * .7*(*deltaTime);  
+                *rotDadoz -= (*rotDadozOffset) * .7 * (*deltaTime);
             }
             // multiplicamos por un escalar para que se vea natural la caida
-            
+
             break;
 
         case 4:
@@ -71,26 +70,26 @@ void Animaciones::animacionDado8Caras(float* rotDadox, float* rotDadoy, float* r
             if (*rotDadoz < 360 - 52) {
                 *rotDadoz += (*rotDadozOffset) * .8 * (*deltaTime);
             }
-           
+
             break;
 
         case 5:
             if (*rotDadoz > -360 - 52) {
-                *rotDadoz -= (*rotDadozOffset) *.7*(*deltaTime);
+                *rotDadoz -= (*rotDadozOffset) * .7 * (*deltaTime);
             }
-            if (*rotDadoy > -360 ) {
+            if (*rotDadoy > -360) {
                 *rotDadoy -= (*rotDadoyOffset) * .8 * (*deltaTime);
             }
             break;
 
         case 6:
-            if (*rotDadox < 52+360+180) {
-                *rotDadox += (*rotDadoxOffset) * .8*(*deltaTime);
+            if (*rotDadox < 52 + 360 + 180) {
+                *rotDadox += (*rotDadoxOffset) * .8 * (*deltaTime);
             }
             if (*rotDadoz < 360) {
-                *rotDadoz += (*rotDadozOffset) *.9* (*deltaTime);
+                *rotDadoz += (*rotDadozOffset) * .9 * (*deltaTime);
             }
-            
+
             break;
 
         case 7:
@@ -106,13 +105,13 @@ void Animaciones::animacionDado8Caras(float* rotDadox, float* rotDadoy, float* r
             if (*rotDadox > -360 - 52) {
                 *rotDadox -= (*rotDadoxOffset) * .7 * (*deltaTime);
             }
-            
-            if (*rotDadoy < 360 ) {
+
+            if (*rotDadoy < 360) {
                 *rotDadoy += (*rotDadoyOffset) * (*deltaTime);
             }
             break;
 
-     
+
         }
 
     }
@@ -129,7 +128,7 @@ void Animaciones::animacionDado8Caras(float* rotDadox, float* rotDadoy, float* r
     }
 }
 void Animaciones::animacionDado4Caras(float* rotDado4x, float* rotDado4y, float* rotDado4z, float* rotDado4xOffset, float* rotDado4yOffset, float* rotDado4zOffset, float* movDado4, float* mov4Offset, Window& mainWindow, float* deltaTime) {
-    
+
     //punto mas bajo  4 en 3
         //PARA 3 CON SIMPLEMENTA BAJAR EN 4 QUEDA
         //para 4 rottar en x -110  pero el punto mas bajo pasa a ser de 0
@@ -150,8 +149,8 @@ void Animaciones::animacionDado4Caras(float* rotDado4x, float* rotDado4y, float*
             numRandom1 = true;
         }
 
-        if (randomNumber2 == 3){
-            if(*movDado4 > -10.0f) {
+        if (randomNumber2 == 3) {
+            if (*movDado4 > -10.0f) {
                 *movDado4 -= (*mov4Offset) * (*deltaTime);
             }
         }
@@ -166,7 +165,7 @@ void Animaciones::animacionDado4Caras(float* rotDado4x, float* rotDado4y, float*
             if (*rotDado4x < 360 + 27) {
                 *rotDado4x += (*rotDado4xOffset) * .5 * (*deltaTime);
             }
-            if (*rotDado4y > -360-12) {
+            if (*rotDado4y > -360 - 12) {
                 *rotDado4y -= (*rotDado4yOffset) * .8 * (*deltaTime);
             }
             if (*rotDado4z > -360 - 105) {
@@ -176,9 +175,9 @@ void Animaciones::animacionDado4Caras(float* rotDado4x, float* rotDado4y, float*
 
         case 2:
             if (*rotDado4y > -360 - 120) {
-                *rotDado4y -= (*rotDado4yOffset) * .6* (*deltaTime);
+                *rotDado4y -= (*rotDado4yOffset) * .6 * (*deltaTime);
             }
-            if (*rotDado4x <  250) {
+            if (*rotDado4x < 250) {
                 *rotDado4x += (*rotDado4xOffset) * .8 * (*deltaTime);
             }
             break;
@@ -193,16 +192,16 @@ void Animaciones::animacionDado4Caras(float* rotDado4x, float* rotDado4y, float*
             break;
 
         case 4:
-            if (*rotDado4x > -360-110) {
-                *rotDado4x -= (*rotDado4xOffset) * .6* (*deltaTime);
+            if (*rotDado4x > -360 - 110) {
+                *rotDado4x -= (*rotDado4xOffset) * .6 * (*deltaTime);
             }
-            if (*rotDado4z < 360 ) {
+            if (*rotDado4z < 360) {
                 *rotDado4z += (*rotDado4zOffset) * .4 * (*deltaTime);
             }
 
             break;
 
-       
+
 
         }
 
@@ -221,12 +220,12 @@ void Animaciones::animacionDado4Caras(float* rotDado4x, float* rotDado4y, float*
     }
 }
 
-void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, float& saltoBenderY, float& desplazamientoBender, int& pasos , float& deltaTime,Window& mainWindow, float& Tiempo,float& desplazamientoBenderz, float& rotacionBenderAux) {
+void Animaciones::movimientoTableroBender(glm::vec3& posicion, float& rotacionBender, float& saltoBenderY, float& desplazamientoBender, int& pasos, float& deltaTime, Window& mainWindow, float& Tiempo, float& desplazamientoBenderz, float& rotacionBenderAux) {
     // el offset de el dezplazamiento de mi modelo sera siempre de .05
     GLfloat rotacionBenderauxiliar = 0;
     GLfloat desplazamientoBenderauxiliar = 0;
-   if (cantidadCasillas !=0 ) {
-       // esquina inferior izquierda
+    if (cantidadCasillas != 0 && mainWindow.turno==2) {
+        // esquina inferior izquierda
         if (posicion.x > -32.0f && posicion.x < -22.0f && posicion.z > -34.0f && posicion.z < -24.0f) {
             if (rotacionBender > -90.0f) {
                 rotacionBender -= (.5f) * (deltaTime);
@@ -251,9 +250,10 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
         else if (posicion.x >= 22.0f && posicion.x <= 32.0f && posicion.z >= -34.0f && posicion.z <= -24.0f) {
             if (rotacionBender > -90.0f) {
                 rotacionBender -= (.5f) * (deltaTime);
-            }else if (desplazamientoBenderz < 7.4f && rotacionBender < -90.0f) {
+            }
+            else if (desplazamientoBenderz < 7.4f && rotacionBender < -90.0f) {
                 desplazamientoBenderz += (.05f) * (deltaTime);
-               
+
             }
             else if (desplazamientoBenderz > 7.4f) {
                 cantidadCasillas--;
@@ -265,16 +265,16 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
                     << "X: " << posicion.x << ", "
                     << "Y: " << posicion.y << ", "
                     << "Z: " << posicion.z << std::endl;
-                
+
             }
 
         }
         // esquina Superior derecha
         else if (posicion.x >= 22.0f && posicion.x <= 32.0f && posicion.z >= 24.0f && posicion.z <= 34.0f) {
-            if (rotacionBender  > -90.0f) {
+            if (rotacionBender > -90.0f) {
                 rotacionBender -= (.5f) * (deltaTime);
             }
-            else if (desplazamientoBender  > -7.75f && rotacionBender < -90.0f) {
+            else if (desplazamientoBender > -7.75f && rotacionBender < -90.0f) {
                 desplazamientoBender -= (.05f) * (deltaTime);
             }
             else if (desplazamientoBender < -7.75f) {
@@ -296,7 +296,7 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
                 rotacionBender -= (.5f) * (deltaTime);
 
             }
-            else if (desplazamientoBenderz  > -7.4f && rotacionBender < -90.0f) {
+            else if (desplazamientoBenderz > -7.4f && rotacionBender < -90.0f) {
                 desplazamientoBenderz -= (.05f) * (deltaTime);
             }
             else if (desplazamientoBenderz < -7.4f) {
@@ -345,13 +345,13 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
                         << "Z: " << posicion.z << std::endl;
                 }
             }
-            
+
 
         }
         // lineas verticales 2
         else if ((posicion.x >= -22.0f && posicion.x <= 22.0f) && posicion.z >= 29.0f) {
-            if ( posicion.x == -19.25f) {
-                if (desplazamientoBender  > -7.75f) {
+            if (posicion.x == -19.25f) {
+                if (desplazamientoBender > -7.75f) {
                     desplazamientoBender -= (.05f) * (deltaTime);
 
                 }
@@ -367,7 +367,7 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
                 }
             }
             else {
-                if (desplazamientoBender  > -5.5f) {
+                if (desplazamientoBender > -5.5f) {
                     desplazamientoBender -= (.05f) * (deltaTime);
                 }
                 else if (desplazamientoBender < -5.5f) {
@@ -386,7 +386,7 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
         }
         // Lineas Horizontales
         else if ((posicion.z >= -24.0f && posicion.z <= 24.0f) && posicion.x == 27.0f) {
-            if ( posicion.z >= 21.6f) { // se pone mayur  o igual ya que puede que el aumento lo tetecte como 21.600000000005 
+            if (posicion.z >= 21.6f) { // se pone mayur  o igual ya que puede que el aumento lo tetecte como 21.600000000005 
                 if (desplazamientoBenderz < 7.4f) {
                     desplazamientoBenderz += (.05f) * (deltaTime);
                 }
@@ -419,15 +419,15 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
         // Lineas Horizontales 2
         else if ((posicion.z >= -24.0f && posicion.z <= 24.0f) && posicion.x == -27.0f) {
             if (posicion.z >= -21.7f && posicion.z <= -21.5f) {
-                if (desplazamientoBenderz  > -7.4f) {
-                   
+                if (desplazamientoBenderz > -7.4f) {
+
                     desplazamientoBenderz -= (.05f) * (deltaTime);
                 }
                 else if (desplazamientoBenderz < -7.4f) {
                     // como esta es la casilla en general vamos a resetear todooo
                     cantidadCasillas--;
                     posicion.x = -27.0f;
-                    posicion.y =  2.5f;
+                    posicion.y = 2.5f;
                     posicion.z = -29.0f;
                     desplazamientoBenderz = 0;
                     desplazamientoBender = 0;
@@ -454,31 +454,264 @@ void Animaciones::movimientoTablero(glm::vec3& posicion, float& rotacionBender, 
 
                 }
             }
-            }
-   }
+        }
+    }
 
 }
+void Animaciones::movimientoTableroDipper(glm::vec3& posicion, float& rotacionBender, float& saltoBenderY, float& desplazamientoBender, int& pasos, float& deltaTime, Window& mainWindow, float& Tiempo, float& desplazamientoBenderz, float& rotacionBenderAux) {
+    // el offset de el dezplazamiento de mi modelo sera siempre de .05
+    GLfloat rotacionBenderauxiliar = 0;
+    GLfloat desplazamientoBenderauxiliar = 0;
+    if (cantidadCasillas != 0 && mainWindow.turno == 1) {
+        // esquina inferior izquierda
+        if (posicion.x > -32.0f && posicion.x < -22.0f && posicion.z > -34.0f && posicion.z < -24.0f) {
+            if (rotacionBender > -90.0f) {
+                rotacionBender -= (.5f) * (deltaTime);
+            }
+            else if (desplazamientoBender < 7.75f && rotacionBender < -90.0f) {
+                desplazamientoBender += (.05f) * (deltaTime);
+            }
+            else if (desplazamientoBender > 7.75f) {
+                cantidadCasillas--;
+                rotacionBenderAux -= 90;
+                rotacionBender = 0;
+                posicion.x += 7.75f;
+                desplazamientoBender = 0;
+                std::cout << "Posición actual del modelo: "
+                    << "X: " << posicion.x << ", "
+                    << "Y: " << posicion.y << ", "
+                    << "Z: " << posicion.z << std::endl;
+            }
+
+        }
+        // esquina inferior derecha
+        else if (posicion.x >= 22.0f && posicion.x <= 32.0f && posicion.z >= -34.0f && posicion.z <= -24.0f) {
+            if (rotacionBender > -90.0f) {
+                rotacionBender -= (.5f) * (deltaTime);
+            }
+            else if (desplazamientoBenderz < 7.4f && rotacionBender < -90.0f) {
+                desplazamientoBenderz += (.05f) * (deltaTime);
+
+            }
+            else if (desplazamientoBenderz > 7.4f) {
+                cantidadCasillas--;
+                rotacionBenderAux -= 90;
+                rotacionBender = 0;
+                posicion.z += 7.4f;
+                desplazamientoBenderz = 0;
+                std::cout << "Posición actual del modelo: "
+                    << "X: " << posicion.x << ", "
+                    << "Y: " << posicion.y << ", "
+                    << "Z: " << posicion.z << std::endl;
+
+            }
+
+        }
+        // esquina Superior derecha
+        else if (posicion.x >= 22.0f && posicion.x <= 32.0f && posicion.z >= 24.0f && posicion.z <= 34.0f) {
+            if (rotacionBender > -90.0f) {
+                rotacionBender -= (.5f) * (deltaTime);
+            }
+            else if (desplazamientoBender > -7.75f && rotacionBender < -90.0f) {
+                desplazamientoBender -= (.05f) * (deltaTime);
+            }
+            else if (desplazamientoBender < -7.75f) {
+                cantidadCasillas--;
+                rotacionBenderAux -= 90;
+                rotacionBender = 0;
+                posicion.x -= 7.75f;
+                desplazamientoBender = 0;
+                std::cout << "Posición actual del modelo: "
+                    << "X: " << posicion.x << ", "
+                    << "Y: " << posicion.y << ", "
+                    << "Z: " << posicion.z << std::endl;
+            }
+
+        }
+        // esquina Superior Izquierda
+        if (posicion.x >= -32.0f && posicion.x <= -22.0f && posicion.z >= 24.0f && posicion.z <= 34.0f) {
+            if (rotacionBender > -90.0f) {
+                rotacionBender -= (.5f) * (deltaTime);
+
+            }
+            else if (desplazamientoBenderz > -7.4f && rotacionBender < -90.0f) {
+                desplazamientoBenderz -= (.05f) * (deltaTime);
+            }
+            else if (desplazamientoBenderz < -7.4f) {
+                cantidadCasillas--;
+                rotacionBenderAux -= 90;
+                rotacionBender = 0;
+                posicion.z -= 7.4f;
+                desplazamientoBenderz = 0;
+                std::cout << "Posición actual del modelo: "
+                    << "X: " << posicion.x << ", "
+                    << "Y: " << posicion.y << ", "
+                    << "Z: " << posicion.z << std::endl;
+            }
+
+        }
+        // lineas verticales 1
+        else if ((posicion.x >= -22.0f && posicion.x <= 22.0f) && posicion.z <= -29.0f) {
+            if (posicion.x == 19.25f) {
+                if (desplazamientoBender < 7.75f) {
+                    desplazamientoBender += (.05f) * (deltaTime);
+
+                }
+                else if (desplazamientoBender > 7.75f) {
+                    cantidadCasillas--;
+
+                    posicion.x += 7.75f;
+                    desplazamientoBender = 0;
+                    std::cout << "Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+                }
+            }
+            else {
+                if (desplazamientoBender < 5.5f) {
+                    desplazamientoBender += (.05f) * (deltaTime);
+                }
+                else if (desplazamientoBender > 5.5f) {
+                    cantidadCasillas--;
+
+                    posicion.x += 5.5f;
+                    desplazamientoBender = 0;
+                    std::cout << "Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+                }
+            }
+
+
+        }
+        // lineas verticales 2
+        else if ((posicion.x >= -22.0f && posicion.x <= 22.0f) && posicion.z >= 29.0f) {
+            if (posicion.x == -19.25f) {
+                if (desplazamientoBender > -7.75f) {
+                    desplazamientoBender -= (.05f) * (deltaTime);
+
+                }
+                else if (desplazamientoBender < -7.75f) {
+                    cantidadCasillas--;
+
+                    posicion.x -= 7.75f;
+                    desplazamientoBender = 0;
+                    std::cout << "Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+                }
+            }
+            else {
+                if (desplazamientoBender > -5.5f) {
+                    desplazamientoBender -= (.05f) * (deltaTime);
+                }
+                else if (desplazamientoBender < -5.5f) {
+                    cantidadCasillas--;
+
+                    posicion.x -= 5.5f;
+                    desplazamientoBender = 0;
+                    std::cout << "Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+                }
+            }
+
+
+        }
+        // Lineas Horizontales
+        else if ((posicion.z >= -24.0f && posicion.z <= 24.0f) && posicion.x == 27.0f) {
+            if (posicion.z >= 21.6f) { // se pone mayur  o igual ya que puede que el aumento lo tetecte como 21.600000000005 
+                if (desplazamientoBenderz < 7.4f) {
+                    desplazamientoBenderz += (.05f) * (deltaTime);
+                }
+                else if (desplazamientoBenderz > 7.4f) {
+                    cantidadCasillas--;
+                    posicion.z += 7.4f;
+                    desplazamientoBenderz = 0;
+                    std::cout << "-----Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+                }
+            }
+            else {
+                if (desplazamientoBenderz < 4.8f) {
+                    desplazamientoBenderz += (.05f) * (deltaTime);
+                }
+                else if (desplazamientoBenderz > 4.8f) {
+                    cantidadCasillas--;
+                    posicion.z += 4.8f;
+                    desplazamientoBenderz = 0;
+                    std::cout << "Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+
+                }
+            }
+        }
+        // Lineas Horizontales 2
+        else if ((posicion.z >= -24.0f && posicion.z <= 24.0f) && posicion.x == -27.0f) {
+            if (posicion.z >= -21.7f && posicion.z <= -21.5f) {
+                if (desplazamientoBenderz > -7.4f) {
+
+                    desplazamientoBenderz -= (.05f) * (deltaTime);
+                }
+                else if (desplazamientoBenderz < -7.4f) {
+                    // como esta es la casilla en general vamos a resetear todooo
+                    cantidadCasillas--;
+                    posicion.x = -27.0f;
+                    posicion.y = 2.5f;
+                    posicion.z = -29.0f;
+                    desplazamientoBenderz = 0;
+                    desplazamientoBender = 0;
+                    rotacionBender = 0;
+                    rotacionBenderAux = 0;
+                    std::cout << "-----Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+                }
+            }
+            else {
+                if (desplazamientoBenderz > -4.8f) {
+                    desplazamientoBenderz -= (.05f) * (deltaTime);
+                }
+                else if (desplazamientoBenderz < -4.8f) {
+                    cantidadCasillas--;
+                    posicion.z -= 4.8f;
+                    desplazamientoBenderz = 0;
+                    std::cout << "Posición actual del modelo: "
+                        << "X: " << posicion.x << ", "
+                        << "Y: " << posicion.y << ", "
+                        << "Z: " << posicion.z << std::endl;
+
+                }
+            }
+        }
+    }
+
+}
+
 //parte animacion de otro modelos
-       
-    
-void Animaciones::animacionTablero(float& posYObjeto, float& rotacionObjeto, float deltaTime) {
-    static bool animacionActiva = false;
-    static float contadorTiempo = 0.0f;
-    const float tiempoEspera = 3.0f;
-    if (!animacionActiva) {
+
+
+void Animaciones::animacionTablero(float& posYObjeto, float& rotacionObjeto, float deltaTime,float Tiempo) {
+    if (!animacionActiva ) {
+        tiempo3segundos = Tiempo + 3.0f;
         animacionActiva = true;
-        contadorTiempo = 0.0f;
     }
     // Usar `objetoID` para cambiar el comportamiento de la animación
-    if (animacionActiva) {
-        if (posYObjeto < 5.0f && contadorTiempo == 0.0f) {
+    if (animacionActiva && cantidadCasillas == 0) {
+        if (posYObjeto < 5.0f && Tiempo < tiempo3segundos ) {
             posYObjeto += 2.0f * deltaTime;
             rotacionObjeto += 90.0f * deltaTime;
         }
-        else if (posYObjeto >= 5.0f && contadorTiempo < tiempoEspera) {
-            contadorTiempo += deltaTime;
-        }
-        else if (contadorTiempo >= tiempoEspera) {
+        else if (Tiempo >= tiempo3segundos) {
             posYObjeto -= 2.0f * deltaTime;
             rotacionObjeto += 90.0f * deltaTime;
             if (posYObjeto <= -5.0f) {
@@ -490,12 +723,12 @@ void Animaciones::animacionTablero(float& posYObjeto, float& rotacionObjeto, flo
     }
 }
 // Función para convertir (X, Z) a un ID de casilla único
-int Animaciones::obtenerIDCasilla(float posXBici, float posZBici) {
+/*int Animaciones::obtenerIDCasilla(float posXBici, float posZBici) {
     if (posXBici == -28.0098f && posZBici == -24.488f) return 1; // Inicio casilla perro
-    if (posXBici == -28.0098f && posZBici == -18.8f) return 2; // Inicio casilla 
-    if (posXBici == -28.0098f && posZBici == -15.08f) return 3; //Inicio casilla 
-    if (posXBici == -28.0098f && posZBici == -10.77f) return 4; //Inicio casilla 
-    if (posXBici == -28.0098f && posZBici == -5.18f) return 5; //Inicio casilla 
+    if (posXBici == -28.0098f && posZBici == -18.8f) return 2; // Inicio casilla
+    if (posXBici == -28.0098f && posZBici == -15.08f) return 3; //Inicio casilla
+    if (posXBici == -28.0098f && posZBici == -10.77f) return 4; //Inicio casilla
+    if (posXBici == -28.0098f && posZBici == -5.18f) return 5; //Inicio casilla
     if (posXBici == -28.0098f && posZBici == -0.49f) return 6; //Inicio casilla elefanbra
     if (posXBici == -28.0098f && posZBici == 4.29f) return 7; //Inicio casilla nueva luz
     if (posXBici == -28.0098f && posZBici == 9.53f) return 8; //Inicio casilla kinopio
@@ -532,7 +765,67 @@ int Animaciones::obtenerIDCasilla(float posXBici, float posZBici) {
     if (posXBici == -15.95f && posZBici == -28.0086f) return 39; //Inicio casilla chapoteo
     if (posXBici == -20.9104f && posZBici == -28.0086f) return 40; //Inicio casilla start
     return -1;  // Retorna -1 si no hay coincidencia
+}*/
+
+
+int Animaciones::obtenerIDCasilla(glm::vec3& posicion) {
+    //Esquina start
+    if (posicion.x > -32.0f && posicion.x < -22.0f && posicion.z > -34.0f && posicion.z < -24.0f) {
+        return 1;
+    }
+    else if ((posicion.x >= -32.0f && posicion.x <= 32.0f) && posicion.z > -34.0f && posicion.z < -24.0f) {
+        if (posicion.x >= -22.0f && posicion.x < -16.5f) return 2;
+        else if (posicion.x >= -16.5f && posicion.x < -11.0f) return 3;
+        else if (posicion.x >= -11.0f && posicion.x < -5.5f) return 4;
+        else if (posicion.x >= -5.5f && posicion.x < 0.0f) return 5;
+        else if (posicion.x >= 0.0f && posicion.x < 5.5f) return 6;
+        else if (posicion.x >= 5.5f && posicion.x < 11.0f) return 7;
+        else if (posicion.x >= 11.0f && posicion.x < 16.5f) return 8;
+        else if (posicion.x >= 16.5f && posicion.x <= 22.0f) return 9;
+        else if (posicion.x >= 22.0f && posicion.x <= 32.0f) return 10;
+    }
+    else if (posicion.z >= -24.0f && posicion.z <= 34.0f && posicion.x >= 22.0f && posicion.x <= 32.0f) {
+        if (posicion.z >= -24.0f && posicion.z < -19.2f) return 11;
+        if (posicion.z >= -19.2f && posicion.z < -14.4f) return 12;
+        if (posicion.z >= -14.4f && posicion.z < -9.6f) return 13;
+        if (posicion.z >= -9.6f && posicion.z < -4.8f) return 14;
+        if (posicion.z >= -4.8f && posicion.z < 0.0f) return 15;
+        if (posicion.z >= 0.0f && posicion.z < 4.8f) return 16;
+        if (posicion.z >= 4.8f && posicion.z < 9.6f) return 17;
+        if (posicion.z >= 9.6f && posicion.z < 14.4f) return 18;
+        if (posicion.z >= 14.4f && posicion.z < 19.2f) return 19;
+        if (posicion.z >= 19.2f && posicion.z <= 24.0f) return 20;
+        if (posicion.z >= 24.0f && posicion.z <= 34.0f) return 21;
+    }
+    else if (posicion.x >= -32.0f && posicion.x <= 22.0f && posicion.z >= 24.0f && posicion.z <= 34.0f) {
+        if (posicion.x <= 22.0f && posicion.x > 16.5f) return 22;
+        if (posicion.x <= 16.5f && posicion.x > 11.0f) return 23;
+        if (posicion.x <= 11.0f && posicion.x > 5.5f) return 24;
+        if (posicion.x <= 5.5f && posicion.x > 0.0f) return 25;
+        if (posicion.x <= 0.0f && posicion.x > -5.5f) return 26;
+        if (posicion.x <= -5.5f && posicion.x > -11.0f) return 27;
+        if (posicion.x <= -11.0f && posicion.x > -16.5f) return 28;
+        if (posicion.x <= -16.5f && posicion.x >= -22.0f) return 29;
+        if (posicion.x <= -22.0f && posicion.x >= -32.0f) return 30;
+    }
+    else if (posicion.x >= -32.0f && posicion.x <= -22.0f && posicion.z >= -24.0f && posicion.z <= 34.0f) {
+        if (posicion.z <= 24.0f && posicion.z > 19.2f) return 31;
+        if (posicion.z <= 19.2f && posicion.z > 14.4f) return 32;
+        if (posicion.z <= 14.4f && posicion.z > 9.6f) return 33;
+        if (posicion.z <= 9.6f && posicion.z > 4.8f) return 34;
+        if (posicion.z <= 4.8f && posicion.z > 0.0f) return 35;
+        if (posicion.z <= 0.0f && posicion.z > -4.8f) return 36;
+        if (posicion.z <= -4.8f && posicion.z > -9.6f) return 37;
+        if (posicion.z <= -9.6f && posicion.z > -14.4f) return 38;
+        if (posicion.z <= -14.4f && posicion.z > -19.2f) return 39;
+        if (posicion.z <= -19.2f && posicion.z >= -24.0f) return 40;
+    }
+    return -1; /// Retorna -1 si no hay coincidencia
+
+
 }
+
+/*
 void Animaciones::controlAnimacionTablero(float posXBici, float posZBici,
     float& posY1, float& rotacion1,
     float& posY2, float& rotacion2,
@@ -696,6 +989,175 @@ void Animaciones::controlAnimacionTablero(float posXBici, float posZBici,
         break;
     case 40:
         animacionTablero(posY40, rotacion40, deltaTime);
+        break;
+    default:
+        break;
+    }
+}*/
+
+void Animaciones::controlAnimacionTablero(glm::vec3& posicion,
+    float& posY1, float& rotacion1,
+    float& posY2, float& rotacion2,
+    float& posY3, float& rotacion3,
+    float& posY4, float& rotacion4,
+    float& posY5, float& rotacion5,
+    float& posY6, float& rotacion6,
+    float& posY7, float& rotacion7,
+    float& posY8, float& rotacion8,
+    float& posY9, float& rotacion9,
+    float& posY10, float& rotacion10,
+    float& posY11, float& rotacion11,
+    float& posY12, float& rotacion12,
+    float& posY13, float& rotacion13,
+    float& posY14, float& rotacion14,
+    float& posY15, float& rotacion15,
+    float& posY16, float& rotacion16,
+    float& posY17, float& rotacion17,
+    float& posY18, float& rotacion18,
+    float& posY19, float& rotacion19,
+    float& posY20, float& rotacion20,
+    float& posY21, float& rotacion21,
+    float& posY22, float& rotacion22,
+    float& posY23, float& rotacion23,
+    float& posY24, float& rotacion24,
+    float& posY25, float& rotacion25,
+    float& posY26, float& rotacion26,
+    float& posY27, float& rotacion27,
+    float& posY28, float& rotacion28,
+    float& posY29, float& rotacion29,
+    float& posY30, float& rotacion30,
+    float& posY31, float& rotacion31,
+    float& posY32, float& rotacion32,
+    float& posY33, float& rotacion33,
+    float& posY34, float& rotacion34,
+    float& posY35, float& rotacion35,
+    float& posY36, float& rotacion36,
+    float& posY37, float& rotacion37,
+    float& posY38, float& rotacion38,
+    float& posY39, float& rotacion39,
+    float& posY40, float& rotacion40,
+    float deltaTime,float Tiempo) {
+    int idCasilla = obtenerIDCasilla(posicion);
+    switch (idCasilla) {
+    case 1:
+        animacionTablero(posY1, rotacion1, deltaTime,Tiempo); //Casilla Guau contador
+        break;
+    case 2:
+        animacionTablero(posY2, rotacion2, deltaTime, Tiempo); //Casilla Start
+        break;
+    case 3:
+        animacionTablero(posY3, rotacion3, deltaTime, Tiempo); //Casilla Chapoteo
+        break;
+    case 4:
+        animacionTablero(posY4, rotacion4, deltaTime, Tiempo); //Casilla Floripondio
+        break;
+    case 5:
+        animacionTablero(posY5, rotacion5, deltaTime, Tiempo); // Casilla Brillantina
+        break;
+    case 6:
+        animacionTablero(posY6, rotacion6, deltaTime, Tiempo); //Casilla Determindes
+        break;
+    case 7:
+        animacionTablero(posY7, rotacion7, deltaTime, Tiempo); //Casilla Impacto
+        break;
+    case 8:
+        animacionTablero(posY8, rotacion8, deltaTime, Tiempo);
+        break;
+    case 9:
+        animacionTablero(posY9, rotacion9, deltaTime, Tiempo); //Casilla Esperanza 
+        break;
+    case 10:
+        animacionTablero(posY10, rotacion10, deltaTime, Tiempo); //Casilla Yahoo 
+        break;
+    case 11:
+        animacionTablero(posY11, rotacion11, deltaTime, Tiempo); //Mystery shack
+        break;
+    case 12:
+        animacionTablero(posY12, rotacion12, deltaTime, Tiempo); //Casilla lento
+        break;
+    case 13:
+        animacionTablero(posY13, rotacion13, deltaTime, Tiempo); //Casilla Castillo del terror
+        break;
+    case 14:
+        animacionTablero(posY14, rotacion14, deltaTime, Tiempo); //Casilla Relajate
+        break;
+    case 15:
+        animacionTablero(posY15, rotacion15, deltaTime, Tiempo); //Casilla Cuidado
+        break;
+    case 16:
+        animacionTablero(posY16, rotacion16, deltaTime, Tiempo);
+        break;
+    case 17:
+        animacionTablero(posY17, rotacion17, deltaTime, Tiempo);
+        break;
+    case 18:
+        animacionTablero(posY18, rotacion18, deltaTime, Tiempo);
+        break;
+    case 19:
+        animacionTablero(posY19, rotacion19, deltaTime, Tiempo);
+        break;
+    case 20:
+        animacionTablero(posY20, rotacion20, deltaTime, Tiempo);
+        break;
+    case 21:
+        animacionTablero(posY21, rotacion21, deltaTime, Tiempo);
+        break;
+    case 22:
+        animacionTablero(posY22, rotacion22, deltaTime, Tiempo);
+        break;
+    case 23:
+        animacionTablero(posY23, rotacion23, deltaTime, Tiempo);
+        break;
+    case 24:
+        animacionTablero(posY24, rotacion24, deltaTime, Tiempo);
+        break;
+    case 25:
+        animacionTablero(posY25, rotacion25, deltaTime, Tiempo);
+        break;
+    case 26:
+        animacionTablero(posY26, rotacion26, deltaTime, Tiempo);
+        break;
+    case 27:
+        animacionTablero(posY27, rotacion27, deltaTime, Tiempo);
+        break;
+    case 28:
+        animacionTablero(posY28, rotacion28, deltaTime, Tiempo);
+        break;
+    case 29:
+        animacionTablero(posY29, rotacion29, deltaTime, Tiempo);
+        break;
+    case 30:
+        animacionTablero(posY30, rotacion30, deltaTime, Tiempo);
+        break;
+    case 31:
+        animacionTablero(posY31, rotacion31, deltaTime, Tiempo);
+        break;
+    case 32:
+        animacionTablero(posY32, rotacion32, deltaTime, Tiempo);
+        break;
+    case 33:
+        animacionTablero(posY33, rotacion33, deltaTime, Tiempo);
+        break;
+    case 34:
+        animacionTablero(posY34, rotacion34, deltaTime, Tiempo);
+        break;
+    case 35:
+        animacionTablero(posY35, rotacion35, deltaTime, Tiempo);
+        break;
+    case 36:
+        animacionTablero(posY36, rotacion36, deltaTime, Tiempo);
+        break;
+    case 37:
+        animacionTablero(posY37, rotacion37, deltaTime, Tiempo);
+        break;
+    case 38:
+        animacionTablero(posY38, rotacion38, deltaTime, Tiempo);
+        break;
+    case 39:
+        animacionTablero(posY39, rotacion39, deltaTime, Tiempo);
+        break;
+    case 40:
+        animacionTablero(posY40, rotacion40, deltaTime, Tiempo);
         break;
     default:
         break;

--- a/Animaciones.h
+++ b/Animaciones.h
@@ -14,11 +14,12 @@ public:
     // Método que sincroniza las animaciones de manera básica para un dado de 8 caras
     void animacionDado8Caras(float* rotDadox, float* rotDadoy, float* rotDadoz, float* rotDadoxOffset, float* rotDadoyOffset, float* rotDadozOffset, float* movDado, float* movOffset, Window& mainWindow, float* deltaTime);
     void animacionDado4Caras(float* rotDado4x, float* rotDado4y, float* rotDado4z, float* rotDado4xOffset, float* rotDado4yOffset, float* rotDado4zOffset, float* movDado4, float* mov4Offset, Window& mainWindow, float* deltaTime);
-    void movimientoTablero(glm::vec3& posicion, float& rotacionBender, float& saltoBenderY, float& desplazamientoBender, int& pasos, float& deltaTime,  Window& mainWindow, float& Tiempo, float& desplazamientoBenderz, float& rotacionBenderAux);
-    
+    void movimientoTableroBender(glm::vec3& posicion, float& rotacionBender, float& saltoBenderY, float& desplazamientoBender, int& pasos, float& deltaTime, Window& mainWindow, float& Tiempo, float& desplazamientoBenderz, float& rotacionBenderAux);
+    void movimientoTableroDipper(glm::vec3& posicion, float& rotacionBender, float& saltoBenderY, float& desplazamientoBender, int& pasos, float& deltaTime, Window& mainWindow, float& Tiempo, float& desplazamientoBenderz, float& rotacionBenderAux);
+
     //animaciones para tablero modelos
-    void animacionTablero(float& posYObjeto, float& rotacionObjeto, float deltaTime);
-    void controlAnimacionTablero(float posXBici, float posZBici,
+    void animacionTablero(float& posYObjeto, float& rotacionObjeto, float deltaTime, float Tiempo);
+    void controlAnimacionTablero(glm::vec3& posicion,
         float& posY1, float& rotacion1,
         float& posY2, float& rotacion2,
         float& posY3, float& rotacion3,
@@ -59,12 +60,14 @@ public:
         float& posY38, float& rotacion38,
         float& posY39, float& rotacion39,
         float& posY40, float& rotacion40,
-        float deltaTime);
-    int obtenerIDCasilla(float posXBici, float posZBici);
+        float deltaTime, float Tiempo);
+    int obtenerIDCasilla(glm::vec3& posicion);
     // Declaraciones públicas de las variables
     int randomNumber1;
     int randomNumber2;
-    int cantidadCasillas=0;
+    int cantidadCasillas = 0;
     bool numRandom = false;
     bool numRandom1 = false;
+    bool animacionActiva = false;
+    GLfloat tiempo3segundos;
 };

--- a/ProyectoFinal.cpp
+++ b/ProyectoFinal.cpp
@@ -64,6 +64,14 @@ float desplazamientoBender = 0.0f;  // Desplazamiento inicial
 float desplazamientoBenderz = 0.0f;
 int pasos = 0;                      // Contador de pasos
 
+//Movimiento tablero dipper
+float rotacionDipper = 0.0f;        // Inicializar rotación de Bender
+float rotacionDipperAux = 0.0f;
+float saltoDipperY = 0.0f;          // Altura del salto en el eje Y
+float desplazamientoDipper = 0.0f;  // Desplazamiento inicial
+float desplazamientoDipperz = 0.0f;
+//int pasosDipper=0;
+
 
 Window mainWindow;
 Animaciones animaciones; //intancia de control de animaciones 
@@ -98,6 +106,19 @@ Model mabel;
 Model stan;
 Model wendy;
 Model mystery_shack;
+Model mansion;
+//Dipper (Personaje principal)
+Model cabezaDipper;
+Model torsoDipper;
+Model antebrazoDipper_der;
+Model antebrazoDipper_izq;
+Model brazoDipper_der;
+Model brazoDipper_izq;
+Model musloDipper_der;
+Model musloDipper_izq;
+Model piernaDipper_der;
+Model piernaDipper_izq;
+
 //AYUDA------
 //Modelo de bicicleta
 Model llantaTrasera;
@@ -343,7 +364,7 @@ void CreateObjects()
 	meshList.push_back(obj4);
 
 	Mesh* obj5 = new Mesh();
-	obj5->CreateMesh(TableroVertices,TableroIndices, 32, 6);
+	obj5->CreateMesh(TableroVertices, TableroIndices, 32, 6);
 	meshList.push_back(obj5);
 
 	Mesh* obj6 = new Mesh();
@@ -376,7 +397,13 @@ void CreateShaders()
 	shader1->CreateFromFiles(vShader, fShader);
 	shaderList.push_back(*shader1);
 }
+
+//Posición inicial Bender
 glm::vec3 position(-27.0f, 2.5f, -29.0f);
+//Auxiliar posicion de Dipper
+glm::vec3 positionDipper(-27.0f, 3.5f, -29.0f);
+//Posicion del turno actual 
+glm::vec3 TurnoActual(0.0f,0.0f,0.0f);
 
 int main()
 {
@@ -394,7 +421,7 @@ int main()
 
 	CreateObjects();
 	CreateShaders();
-	
+
 
 	TableroCentroTexture = Texture("Textures/TableroCentro.tga");
 	TableroCentroTexture.LoadTextureA();
@@ -444,7 +471,7 @@ int main()
 
 	BenderPiernaIzqSup = Model();
 	BenderPiernaIzqSup.LoadModel("Models/Bender_PiernaIzqSup.obj");
-	//-------------------Modelos Gravity Falls
+	//----------------------------------Modelos Gravity Falls
 	bill = Model();
 	bill.LoadModel("Models/bill.obj");
 	cabra = Model();
@@ -467,6 +494,30 @@ int main()
 	wendy.LoadModel("Models/wendy.obj");
 	mystery_shack = Model();
 	mystery_shack.LoadModel("Models/mystery_shack.obj");
+	mansion = Model();
+	mansion.LoadModel("Models/mansion.obj");
+	//Dipper
+	cabezaDipper = Model();
+	cabezaDipper.LoadModel("Models/cabezaDipper.obj");
+	torsoDipper = Model();
+	torsoDipper.LoadModel("Models/torsoDipper.obj");
+	antebrazoDipper_der = Model();
+	antebrazoDipper_der.LoadModel("Models/antebrazoDipper_der.obj");
+	antebrazoDipper_izq = Model();
+	antebrazoDipper_izq.LoadModel("Models/antebrazoDipper_izq.obj");
+	brazoDipper_der = Model();
+	brazoDipper_der.LoadModel("Models/brazoDipper_der.obj");
+	brazoDipper_izq = Model();
+	brazoDipper_izq.LoadModel("Models/brazoDipper_izq.obj");
+	musloDipper_der = Model();
+	musloDipper_der.LoadModel("Models/musloDipper_der.obj");
+	musloDipper_izq = Model();
+	musloDipper_izq.LoadModel("Models/musloDipper_izq.obj");
+	piernaDipper_der = Model();
+	piernaDipper_der.LoadModel("Models/piernaDipper_der.obj");
+	piernaDipper_izq = Model();
+	piernaDipper_izq.LoadModel("Models/piernaDipper_izq.obj");
+
 	//-----------------------------------------Bicicleta
 	llantaTrasera = Model();
 	llantaTrasera.LoadModel("Models/llanta_trasera.obj");
@@ -483,7 +534,7 @@ int main()
 	skyboxFaces.push_back("Textures/Skybox/EspacioCicloNoche_Up.tga");
 	skyboxFaces.push_back("Textures/Skybox/EspacioCicloNoche_Bk.tga");
 	skyboxFaces.push_back("Textures/Skybox/EspacioCicloNoche_Ft.tga");
-	
+
 	//Para el ciclo de dia 
 	/*skyboxFaces.push_back("Textures/Skybox/SkyboxCicloDia_Lf.tga");
 	skyboxFaces.push_back("Textures/Skybox/SkyboxCicloDia_Rt.tga");
@@ -535,7 +586,7 @@ int main()
 
 	int lastModoCamara = camera.getModoCamara();
 
-	
+
 	toffsetTablerou = 0.0;
 	toffsetTablerov = 0.0;
 	// aqui se inicia todo
@@ -557,7 +608,7 @@ int main()
 	float xObjetivoNegativo = -28.0f;  // Punto donde nos detenemos en -x
 	//Todos los límites son con respecto a como mi modelo sigue dentro del tablero
 	int estado = 0;  // Control de fases: 0: Avanzar en Z positivo, 1: Girar a X, 2: Avanzar en X, 3: Girar a Z negativo, 4: Avanzar en Z negativo, 5: Gira a X negativo, 6: Avanza en X negativo y 7: Gira a Z positivo
-	
+
 	float posYObjeto1 = -5.0f, posYObjeto2 = -5.0f, posYObjeto3 = -5.0f, posYObjeto4 = -5.0f, posYObjeto5 = -5.0f, posYObjeto6 = -5.0f, posYObjeto7 = -5.0f, posYObjeto8 = -5.0f, posYObjeto9 = -5.0f, posYObjeto10 = -5.0f, posYObjeto11 = -5.0f, posYObjeto12 = -5.0f, posYObjeto13 = -5.0f, posYObjeto14 = -5.0f, posYObjeto15 = -5.0f, posYObjeto16 = -5.0f, posYObjeto17 = -5.0f, posYObjeto18 = -5.0f, posYObjeto19 = -5.0f, posYObjeto20 = -5.0f, posYObjeto21 = -5.0f, posYObjeto22 = -5.0f, posYObjeto23 = -5.0f, posYObjeto24 = -5.0f, posYObjeto25 = -5.0f, posYObjeto26 = -5.0f, posYObjeto27 = -5.0f, posYObjeto28 = -5.0f, posYObjeto29 = -5.0f, posYObjeto30 = -5.0f, posYObjeto31 = -5.0f, posYObjeto32 = -5.0f, posYObjeto33 = -5.0f, posYObjeto34 = -5.0f, posYObjeto35 = -5.0f, posYObjeto36 = -5.0f, posYObjeto37 = -5.0f, posYObjeto38 = -5.0f, posYObjeto39 = -5.0f, posYObjeto40 = -5.0f;
 	float rotacionObjeto1 = 0.0f, rotacionObjeto2 = 0.0f, rotacionObjeto3 = 0.0f, rotacionObjeto4 = 0.0f, rotacionObjeto5 = 0.0f, rotacionObjeto6 = 0.0f, rotacionObjeto7 = 0.0f, rotacionObjeto8 = 0.0f, rotacionObjeto9 = 0.0f, rotacionObjeto10 = 0.0f, rotacionObjeto11 = 0.0f, rotacionObjeto12 = 0.0f, rotacionObjeto13 = 0.0f, rotacionObjeto14 = 0.0f, rotacionObjeto15 = 0.0f, rotacionObjeto16 = 0.0f, rotacionObjeto17 = 0.0f, rotacionObjeto18 = 0.0f, rotacionObjeto19 = 0.0f, rotacionObjeto20 = 0.0f, rotacionObjeto21 = 0.0f, rotacionObjeto22 = 0.0f, rotacionObjeto23 = 0.0f, rotacionObjeto24 = 0.0f, rotacionObjeto25 = 0.0f, rotacionObjeto26 = 0.0f, rotacionObjeto27 = 0.0f, rotacionObjeto28 = 0.0f, rotacionObjeto29 = 0.0f, rotacionObjeto30 = 0.0f, rotacionObjeto31 = 0.0f, rotacionObjeto32 = 0.0f, rotacionObjeto33 = 0.0f, rotacionObjeto34 = 0.0f, rotacionObjeto35 = 0.0f, rotacionObjeto36 = 0.0f, rotacionObjeto37 = 0.0f, rotacionObjeto38 = 0.0f, rotacionObjeto39 = 0.0f, rotacionObjeto40 = 0.0f;
 
@@ -566,6 +617,7 @@ int main()
 		GLfloat now = glfwGetTime();
 		deltaTime = now - lastTime;
 		Tiempo += now - lastTime;
+		printf("tiempo actual :  %f \n", Tiempo);
 		deltaTime += (now - lastTime) / limitFPS;
 		lastTime = now;
 		animaciones.animacionDado8Caras(
@@ -580,6 +632,8 @@ int main()
 			&movDado4, &mov4Offset,
 			mainWindow, &deltaTime
 		);
+		
+
 		////--------------------------------------------------AYUDA
 		/*switch (estado) {
 			// Fase 1: Avanzar en Z positivo
@@ -984,6 +1038,12 @@ int main()
 		dado_4_Caras.UseTexture();
 		meshList[8]->RenderMesh();
 
+		if (mainWindow.turno == 1) {	
+			TurnoActual = positionDipper;
+		}
+		else if (mainWindow.turno == 2) {
+			TurnoActual = position;
+		}
 
 		glEnable(GL_BLEND);
 		//------------*MODELO JERARQUICO DE BENDER-------------------*
@@ -991,9 +1051,9 @@ int main()
 		model = glm::mat4(1.0);
 		model = glm::translate(model, position);
 		// Extraer la posición actual de la matriz de model
-		animaciones.movimientoTablero(position, rotacionBender, saltoBenderY, desplazamientoBender, pasos, deltaTime, mainWindow,Tiempo, desplazamientoBenderz, rotacionBenderAux);
-		model = glm::translate(model, glm::vec3(0.0f+desplazamientoBender, 0.0f, 0.0f+desplazamientoBenderz));
-		model = glm::rotate(model, (rotacionBender + rotacionBenderAux-180) * toRadians, glm::vec3(0.0f, 1.0f, 0.0f));
+		animaciones.movimientoTableroBender(position, rotacionBender, saltoBenderY, desplazamientoBender, pasos, deltaTime, mainWindow, Tiempo, desplazamientoBenderz, rotacionBenderAux);
+		model = glm::translate(model, glm::vec3(0.0f + desplazamientoBender, 0.0f, 0.0f + desplazamientoBenderz));
+		model = glm::rotate(model, (rotacionBender + rotacionBenderAux - 180) * toRadians, glm::vec3(0.0f, 1.0f, 0.0f));
 		/*std::cout << "Posición actual del modelo: "
 			<< "X: " << position.x << ", "
 			<< "Y: " << position.y << ", "
@@ -1004,10 +1064,10 @@ int main()
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		BenderTorzo.RenderModel();
-		
+
 
 		// Imprimir la posición
-		
+
 		//-- Cabeza
 		model = modelaux;
 		model = glm::translate(model, glm::vec3(0.0f, 2.7f, 0.0f));
@@ -1095,19 +1155,130 @@ int main()
 		BenderPiernaIzqInf.RenderModel();
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glDisable(GL_BLEND);
-		
+
+		//------------*MODELO JERARQUICO DE DIPPER -------------------*
+		// --- TORSO
+		model = glm::mat4(1.0);
+		model = glm::translate(model, positionDipper);
+		//model = glm::translate(model, glm::vec3(-0.3f + desplazamientoBender, 0.5f, 0.0f + desplazamientoBenderz));
+		animaciones.movimientoTableroDipper(positionDipper, rotacionDipper, saltoDipperY, desplazamientoDipper, pasos, deltaTime, mainWindow, Tiempo, desplazamientoDipperz, rotacionDipperAux);
+		model = glm::translate(model, glm::vec3(0.0f + desplazamientoDipper, 0.0f, 0.0f + desplazamientoDipperz));
+		model = glm::rotate(model, (rotacionDipper + rotacionDipperAux - 180) * toRadians, glm::vec3(0.0f, 1.0f, 0.0f));
+		/*std::cout << "Posición actual del modelo: "
+			<< "X: " << position.x << ", "
+			<< "Y: " << position.y << ", "
+			<< "Z: " << position.z << std::endl;*/
+		modelaux = model;
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		torsoDipper.RenderModel();
+
+
+		// Imprimir la posición
+
+		//-- Cabeza
+		model = modelaux;
+		model = glm::translate(model, glm::vec3(0.05f, 0.48f, 0.13f));
+		model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(1.0f, 0.0f, 0.0f));
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		cabezaDipper.RenderModel();
+		//-- Brazo Derecho 
+		model = modelaux;
+		model = glm::translate(model, glm::vec3(-0.35f, 0.28f, 0.1f));
+		model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(1.0f, 0.0f, 0.0f));
+		modelaux2 = model;
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		brazoDipper_der.RenderModel();
+		// -- Antebrazo Derecho
+		model = modelaux2;
+		model = glm::translate(model, glm::vec3(-0.02f, -0.57f, 0.05f));
+		//model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		antebrazoDipper_der.RenderModel();
+		// Brazo Izquierdo
+		model = modelaux;
+		model = glm::translate(model, glm::vec3(0.36f, 0.28f, 0.1f));
+		model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(1.0f, 0.0f, 0.0f));
+		modelaux2 = model;
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		brazoDipper_izq.RenderModel();
+		// Antebrazo izquierdo
+		model = modelaux2;
+		model = glm::translate(model, glm::vec3(0.01f, -0.59f, 0.02f));
+		//model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		antebrazoDipper_izq.RenderModel();
+		// Muslo Derecha
+		model = modelaux;
+		model = glm::translate(model, glm::vec3(-0.1f, -0.52f, 0.05f));
+		model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(1.0f, 0.0f, 0.0f));
+		modelaux2 = model;
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		musloDipper_der.RenderModel();
+		// Pierna Derecha
+		model = modelaux2;
+		model = glm::translate(model, glm::vec3(-0.027f, -0.3f, 0.031f));
+		//model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		piernaDipper_der.RenderModel();
+		// Muslo  Izquierdo contador
+		model = modelaux;
+		model = glm::translate(model, glm::vec3(0.21f, -0.5f, 0.05f));
+		model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(1.0f, 0.0f, 0.0f));
+		modelaux2 = model;
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		musloDipper_izq.RenderModel();
+		// Pierna Izquierda
+		model = modelaux2;
+		model = glm::translate(model, glm::vec3(-0.022f, -0.32f, 0.07f));
+		//model = glm::rotate(model, mainWindow.rotx * toRadians, glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
+		color = glm::vec3(1.0f, 1.0f, 1.0f);
+		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
+		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
+		piernaDipper_izq.RenderModel();
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		glDisable(GL_BLEND);
 
 		// Aqui inicia el sufrir unu
 				//------------------------ OBJETOS TABLERO
 		//Llamada a controlAnimacionTablero con las coordenadas de la bicicleta y todos los objetos de nuestro tablero (Ajustar traslacion y escala si es necesario para su objeto)
-		animaciones.controlAnimacionTablero(posicionX, posicionZ, posYObjeto1, rotacionObjeto1, posYObjeto2, rotacionObjeto2, posYObjeto3, rotacionObjeto3, posYObjeto4, rotacionObjeto4, posYObjeto5, rotacionObjeto5, posYObjeto6, rotacionObjeto6, posYObjeto7, rotacionObjeto7, posYObjeto8, rotacionObjeto8, posYObjeto9, rotacionObjeto9, posYObjeto10, rotacionObjeto10, posYObjeto11, rotacionObjeto11, posYObjeto12, rotacionObjeto12, posYObjeto13, rotacionObjeto13, posYObjeto14, rotacionObjeto14, posYObjeto15, rotacionObjeto15, posYObjeto16, rotacionObjeto16, posYObjeto17, rotacionObjeto17, posYObjeto18, rotacionObjeto18, posYObjeto19, rotacionObjeto19, posYObjeto20, rotacionObjeto20, posYObjeto21, rotacionObjeto21, posYObjeto22, rotacionObjeto22, posYObjeto23, rotacionObjeto23, posYObjeto24, rotacionObjeto24, posYObjeto25, rotacionObjeto25, posYObjeto26, rotacionObjeto26, posYObjeto27, rotacionObjeto27, posYObjeto28, rotacionObjeto28, posYObjeto29, rotacionObjeto29, posYObjeto30, rotacionObjeto30, posYObjeto31, rotacionObjeto31, posYObjeto32, rotacionObjeto32, posYObjeto33, rotacionObjeto33, posYObjeto34, rotacionObjeto34, posYObjeto35, rotacionObjeto35, posYObjeto36, rotacionObjeto36, posYObjeto37, rotacionObjeto37, posYObjeto38, rotacionObjeto38, posYObjeto39, rotacionObjeto39, posYObjeto40, rotacionObjeto40, deltaTime);
+
+		//Llamada a función con posicion del personaje para activar animación de tablero
+		animaciones.controlAnimacionTablero(TurnoActual, posYObjeto1, rotacionObjeto1, posYObjeto2, rotacionObjeto2, posYObjeto3, rotacionObjeto3, posYObjeto4, rotacionObjeto4, posYObjeto5, rotacionObjeto5, posYObjeto6, rotacionObjeto6, posYObjeto7, rotacionObjeto7, posYObjeto8, rotacionObjeto8, posYObjeto9, rotacionObjeto9, posYObjeto10, rotacionObjeto10, posYObjeto11, rotacionObjeto11, posYObjeto12, rotacionObjeto12, posYObjeto13, rotacionObjeto13, posYObjeto14, rotacionObjeto14, posYObjeto15, rotacionObjeto15, posYObjeto16, rotacionObjeto16, posYObjeto17, rotacionObjeto17, posYObjeto18, rotacionObjeto18, posYObjeto19, rotacionObjeto19, posYObjeto20, rotacionObjeto20, posYObjeto21, rotacionObjeto21, posYObjeto22, rotacionObjeto22, posYObjeto23, rotacionObjeto23, posYObjeto24, rotacionObjeto24, posYObjeto25, rotacionObjeto25, posYObjeto26, rotacionObjeto26, posYObjeto27, rotacionObjeto27, posYObjeto28, rotacionObjeto28, posYObjeto29, rotacionObjeto29, posYObjeto30, rotacionObjeto30, posYObjeto31, rotacionObjeto31, posYObjeto32, rotacionObjeto32, posYObjeto33, rotacionObjeto33, posYObjeto34, rotacionObjeto34, posYObjeto35, rotacionObjeto35, posYObjeto36, rotacionObjeto36, posYObjeto37, rotacionObjeto37, posYObjeto38, rotacionObjeto38, posYObjeto39, rotacionObjeto39, posYObjeto40, rotacionObjeto40, deltaTime,Tiempo);
 		//Casilla Start
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto1, -30.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto2, -30.0f));
 		//model = glm::translate(model, glm::vec3(-35.0f, posYObjeto1, 7.0f)); //Bill
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto1), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto2), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1117,9 +1288,9 @@ int main()
 		//Casilla Guau
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto2, -22.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto1, -22.0f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto2), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto1), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1129,9 +1300,9 @@ int main()
 		//Casilla Sigue Avanzando
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto3, -17.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto40, -17.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto3), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto40), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1141,9 +1312,9 @@ int main()
 		//Casilla Espacio Naturaleza (4)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto4, -12.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto39, -12.0f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto4), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto39), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1153,9 +1324,9 @@ int main()
 		//Casilla Soos (5)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto5, -7.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto38, -7.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto5), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto38), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1165,9 +1336,9 @@ int main()
 		//Casilla Gran Castillo (6)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto6, -2.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto37, -2.0f));
 		model = glm::scale(model, glm::vec3(0.05f, 0.05f, 0.05f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto6), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto37), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1177,9 +1348,9 @@ int main()
 		//Casilla Elefanbria (7)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto7, 3.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto36, 3.0f));
 		model = glm::scale(model, glm::vec3(1.0f, 1.0f, 1.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto7), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto36), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1189,9 +1360,9 @@ int main()
 		//Casilla Nueva luz (8)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto8, 7.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto35, 7.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto8), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto35), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1201,9 +1372,9 @@ int main()
 		//Casilla Kinopio (9)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto9, 13.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto34, 13.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto9), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto34), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1213,9 +1384,9 @@ int main()
 		//Casilla Oink (10)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto10, 17.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto33, 17.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto10), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto33), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1224,9 +1395,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Puerto diversion (11)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto11, 22.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto32, 22.0f));
 		model = glm::scale(model, glm::vec3(2.0f, 2.0f, 2.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto11), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto32), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1235,9 +1406,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Insert Coin (12)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto12, 30.0f));
+		model = glm::translate(model, glm::vec3(-37.0f, posYObjeto31, 30.0f));
 		model = glm::scale(model, glm::vec3(0.2f, 0.2f, 0.2f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto12), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto31), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1247,9 +1418,9 @@ int main()
 		//Casilla Mordelon (13)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-19.5f, posYObjeto13, 38.0f));
+		model = glm::translate(model, glm::vec3(-19.5f, posYObjeto30, 38.0f));
 		model = glm::scale(model, glm::vec3(1.0f, 1.0f, 1.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto13), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto30), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1258,9 +1429,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Te tengo (14)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(-14.0f, posYObjeto14, 38.0f));
+		model = glm::translate(model, glm::vec3(-14.0f, posYObjeto29, 38.0f));
 		model = glm::scale(model, glm::vec3(2.0f, 2.0f, 2.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto14), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto29), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1269,9 +1440,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Destronador (15)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(-8.5f, posYObjeto15, 38.0f));
+		model = glm::translate(model, glm::vec3(-8.5f, posYObjeto28, 38.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto15), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto28), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1280,9 +1451,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla trebol de 7 (16)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(-3.0f, posYObjeto16, 38.0f));
+		model = glm::translate(model, glm::vec3(-3.0f, posYObjeto27, 38.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto16), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto27), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1292,9 +1463,9 @@ int main()
 		//Casilla Estafado (17)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(2.5f, posYObjeto17, 38.0f));
+		model = glm::translate(model, glm::vec3(2.5f, posYObjeto26, 38.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto17), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto26), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1304,9 +1475,9 @@ int main()
 		//Casilla Mazmorra (18)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(8.0f, posYObjeto18, 38.0f));
+		model = glm::translate(model, glm::vec3(8.0f, posYObjeto25, 38.0f));
 		model = glm::scale(model, glm::vec3(0.05f, 0.05f, 0.05f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto18), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto25), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1316,9 +1487,9 @@ int main()
 		//Casilla Devorado (19)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(13.5f, posYObjeto19, 38.0f));
+		model = glm::translate(model, glm::vec3(13.5f, posYObjeto24, 38.0f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto19), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto24), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1328,9 +1499,9 @@ int main()
 		//Casilla Gnomo (20)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(18.5f, posYObjeto20, 38.0f));
+		model = glm::translate(model, glm::vec3(18.5f, posYObjeto23, 38.0f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto20), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto23), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1339,9 +1510,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla trbunal (esquina) (21)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(24.5f, posYObjeto21, 38.0f));
+		model = glm::translate(model, glm::vec3(24.5f, posYObjeto22, 38.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto21), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto22), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1351,9 +1522,9 @@ int main()
 		//Casilla Saltarin (22)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto22, 21.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto21, 21.5f));
 		model = glm::scale(model, glm::vec3(1.0f, 1.0f, 1.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto22), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto21), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1363,9 +1534,9 @@ int main()
 		//Casilla Cabra (23)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto23, 16.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto20, 16.5f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto23), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto20), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1374,9 +1545,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla a comer (24)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto24, 11.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto19, 11.5f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto24), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto19), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1386,9 +1557,9 @@ int main()
 		//Casilla Mr Langosta (25)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto25, 6.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto18, 6.5f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto25), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto18), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1397,21 +1568,21 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Mansion Noroeste (26)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto26, 1.5f));
-		model = glm::scale(model, glm::vec3(1.0f, 1.0f, 1.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto26), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto17, 1.5f));
+		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto17), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		mabel.RenderModel();
+		mansion.RenderModel();
 		//Reestablece
 		model = glm::mat4(1.0);
 		//Casilla Furia(27)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto27, -4.0f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto16, -4.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto27), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto16), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1420,9 +1591,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Cuidado (28)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto28, -7.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto15, -7.5f));
 		model = glm::scale(model, glm::vec3(0.05f, 0.05f, 0.05f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto28), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto15), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1431,9 +1602,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Relajate (29)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto29, -11.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto14, -11.5f));
 		model = glm::scale(model, glm::vec3(2.0f, 2.0f, 2.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto29), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto14), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1443,9 +1614,9 @@ int main()
 		//Casilla Castillo del terror (30)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto30, -16.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto13, -16.5f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto30), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto13), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1455,9 +1626,9 @@ int main()
 		//Casilla Lento (31)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto31, -21.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto12, -21.5f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto31), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto12), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1466,9 +1637,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Mystery Shack (32)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(36.5f, posYObjeto32, -28.5f));
+		model = glm::translate(model, glm::vec3(36.5f, posYObjeto11, -28.5f));
 		model = glm::scale(model, glm::vec3(0.2f, 0.2f, 0.2f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto32), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto11), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1478,9 +1649,9 @@ int main()
 		//Casilla Yahoo (33)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(19.5f, posYObjeto33, -39.0f));
+		model = glm::translate(model, glm::vec3(19.5f, posYObjeto10, -39.0f));
 		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto33), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto10), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1490,9 +1661,9 @@ int main()
 		//Casilla Esperanza (34)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(14.0f, posYObjeto34, -39.0f));
+		model = glm::translate(model, glm::vec3(14.0f, posYObjeto9, -39.0f));
 		model = glm::scale(model, glm::vec3(0.05f, 0.05f, 0.05f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto34), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto9), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1502,9 +1673,9 @@ int main()
 		//Casilla Bulldog (35)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(8.f, posYObjeto35, -39.0f));
+		model = glm::translate(model, glm::vec3(8.f, posYObjeto8, -39.0f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto35), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto8), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1514,9 +1685,9 @@ int main()
 		//Casilla Impacto (36)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(4.0f, posYObjeto36, -39.0f));
+		model = glm::translate(model, glm::vec3(4.0f, posYObjeto7, -39.0f));
 		model = glm::scale(model, glm::vec3(0.05f, 0.05f, 0.05f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto36), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto7), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1525,9 +1696,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Determined (37)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(-1.0f, posYObjeto37, -39.0f));
+		model = glm::translate(model, glm::vec3(-1.0f, posYObjeto6, -39.0f));
 		model = glm::scale(model, glm::vec3(1.0f, 1.0f, 1.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto37), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto6), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1536,9 +1707,9 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Brillantina (38)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		model = glm::translate(model, glm::vec3(-8.0f, posYObjeto38, -39.0f));
+		model = glm::translate(model, glm::vec3(-8.0f, posYObjeto5, -39.0f));
 		model = glm::scale(model, glm::vec3(1.0f, 1.0f, 1.0f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto38), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto5), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1548,9 +1719,9 @@ int main()
 		//Casilla Floripondio (39)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-13.0f, posYObjeto39, -39.0f));
+		model = glm::translate(model, glm::vec3(-13.0f, posYObjeto4, -39.0f));
 		model = glm::scale(model, glm::vec3(0.05f, 0.05f, 0.05f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto39), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto4), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
@@ -1559,41 +1730,14 @@ int main()
 		model = glm::mat4(1.0);
 		//Casilla Chapoteo (40)
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
-		//model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(-18.0f, posYObjeto40, -39.0f));
+		model = glm::translate(model, glm::vec3(-18.0f, posYObjeto3, -39.0f));
 		model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-		model = glm::rotate(model, glm::radians(rotacionObjeto40), glm::vec3(0.0f, 1.0f, 0.0f));
+		model = glm::rotate(model, glm::radians(rotacionObjeto3), glm::vec3(0.0f, 1.0f, 0.0f));
 		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
 		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
 		glUniform2fv(uniformTextureOffset, 1, glm::value_ptr(toffset));
 		dipper.RenderModel();
-		//----------------------AYUDA
-		//---------------Instanciando nuestra bici
-		// Inicio (Casilla cabaña Gravity falls): (-28.0f, 3.9f, -25.0f) (Avanzar todo eje z hasta 25 en z)
-		//-----------------Base
-		model = glm::mat4(1.0);
-		model = glm::translate(model, glm::vec3(posicionX, posicionY, posicionZ));
-		model = glm::rotate(model, rotacionY, glm::vec3(0.0f, 1.0f, 0.0f));
-		model = glm::scale(model, glm::vec3(0.5f, 0.5f, 0.5f));
-		modelaux = model;
-		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
-		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
-		bicicleta.RenderModel();
-		//-----------------Llanta delantera
-		model = modelaux;
-		model = glm::translate(model, glm::vec3(0.0f, -1.9f, 3.4f));
-		model = glm::rotate(model, rotacionRueda, glm::vec3(1.0f, 0.0f, 0.0f));
-		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
-		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
-		llantaDelantera.RenderModel();
-		//-----------------Llanta trasera
-		model = modelaux;
-		model = glm::translate(model, glm::vec3(0.0f, -1.9f, -5.8f));
-		model = glm::rotate(model, rotacionRueda, glm::vec3(1.0f, 0.0f, 0.0f));
-		glUniform3fv(uniformColor, 1, glm::value_ptr(color));
-		glUniformMatrix4fv(uniformModel, 1, GL_FALSE, glm::value_ptr(model));
-		llantaTrasera.RenderModel();
-
+		
 		glUseProgram(0);
 
 		mainWindow.swapBuffers();

--- a/Window.cpp
+++ b/Window.cpp
@@ -169,6 +169,24 @@ void Window::ManejaTeclado(GLFWwindow* window, int key, int code, int action, in
 	{
 		theWindow->Avanza = !theWindow->Avanza;
 		printf("¿Dado cae? %s \n", theWindow->Avanza ? "En efecto" : "Nel");
+
+		printf("\nCantidadEsp =: %d \n", theWindow->CantidadEsp);
+		// Cambia de turno en cada segunda pulsación
+		if (theWindow->CantidadEsp == 0) {
+			theWindow->CantidadEsp = 1; // Marca la primera pulsación
+		}
+		else {
+			// Segunda pulsación: cambia el turno
+			theWindow->turno += 1; // Incrementa el turno
+			if (theWindow->turno > 2) { // Resetea el turno si excede 2
+				theWindow->turno = 1;
+			}
+			theWindow->CantidadEsp = 0;
+		}
+
+		
+		
+		
 	}
 
 

--- a/Window.h
+++ b/Window.h
@@ -16,6 +16,8 @@ public:
 	GLboolean getBandera();
 	GLfloat getmuevex() { return muevex; }
 	GLint rotx, roty, rotz;
+	GLint turno = 1;
+	GLint CantidadEsp = 0;
 	bool getShouldClose() {
 		return  glfwWindowShouldClose(mainWindow);}
 	bool* getsKeys() { return keys; }


### PR DESCRIPTION
ya existe un logica al tirar, primero va dipper luego bender (si se alcanza a poner a peach mañana ya tambien se puede implementar), y conforme pasen las casillas, ya se puede salir el objeto especia, y simular su rotacion por 3 segundos, implementar solamente una logica para que cuando se cambie de turno este objeto se regresa a abajo del tablero